### PR TITLE
Update @supercollectible/Valence to v3.2.2

### DIFF
--- a/skillsets/@supercollectible/Valence/content/INSTALL_NOTES.md
+++ b/skillsets/@supercollectible/Valence/content/INSTALL_NOTES.md
@@ -1,8 +1,23 @@
 # Valence
 
-Hey, welcome to Valence, a spec-driven Claude Code skillset with adversarial review, QA agents, and orchestrated builds. Built for agency over automation — you own the decisions, agents handle the execution.
+Welcome! Valence is a spec-driven Claude Code skillset with adversarial review, QA agents, and orchestrated builds.
 
-The install agent will walk you through adapting the primitives to your stack. Have fun!
+A lot of tooling in this space optimizes for how little you have to do. Valence optimizes for the quality of what gets built, and how well you understand the system. That's a deliberate design decision, not a gap. Agency over automation.
+
+**What the team does:** gruntwork and signal. It handles mechanical execution — implementation, testing, documentation, cleanup. And it surfaces structured data for your decisions: grounding research against real docs, adversarial critiques from models with different blind spots, claim-by-claim validation verdicts, QA findings by severity. It produces proposals and reports, not decisions.
+
+**What stays with you:**
+
+- **Vision and direction.** The architecture, the UX, the product shape — yours. The team works from your intent, not its own.
+- **System comprehension.** Valence surfaces what you need to understand the structure, when you need it. Not a black box. You always know why.
+- **Git.** Commits, branches, rollbacks — your responsibility.
+- **Complexity routing.** When to `/solve` vs `/build`, when to loop back to `/arch` vs patch in place, when to skip the workflow entirely and just ask Claude — that's judgment, not automation. The primitives are modular for a reason.
+- **Decision gates.** Every gate produces a proposal, not a final answer. `/arm` produces a brief for sign-off. `/ar` surfaces critiques for triage. `/breakdown` produces a plan you approve before a single build agent starts.
+- **Supervision.** Agent teams are experimental. Expect small failures — missed messages, stalled tasks. Expect occasional bigger ones. Watch the team while it works.
+
+**On interruption:** In `/arch`, `/solve`, and `/bugfest`, the lead is reasoning actively. If you see it going wrong — stop it. Contradicting mid-stream is cheaper than correcting a finished design doc.
+
+You're in charge. 
 
 ## Dependencies
 
@@ -21,7 +36,7 @@ Context7 provides live library documentation lookup during design and review pha
 |------|---------|----------|-----------------|
 | Valence_ext/package.json | npm | @modelcontextprotocol/sdk, server-filesystem, context7-mcp, zod | No |
 
-The Valence_ext stack uses the official MCP SDK (5M+ weekly downloads, Anthropic org) and zod (87M+ weekly downloads) for external model agent running. The filesystem and context7 packages are pre-installed for local npx resolution. No lifecycle scripts. Only needed if you use `/ar` or `/pmatch` with external models (Kimi, GLM-5).
+Valence_ext runs external models for `/ar` and `/pmatch`. Uses the official MCP SDK (5M+ weekly downloads, Anthropic org) and zod (87M+ weekly downloads). The filesystem and context7 packages are pre-installed for local npx resolution. No lifecycle scripts. Run `cd Valence_ext && npm install` before first use.
 
 ### Claude Code Extensions
 

--- a/skillsets/@supercollectible/Valence/skillset.yaml
+++ b/skillsets/@supercollectible/Valence/skillset.yaml
@@ -3,7 +3,7 @@ batch_id: "2.10.001"
 
 # Identity
 name: "Valence"
-version: "3.2.1"
+version: "3.2.2"
 description: "Spec-driven Claude Code workflow with adversarial review, QA agents, and orchestrated builds"
 
 author:


### PR DESCRIPTION
## Skillset Update

**Skillset:** @supercollectible/Valence
**Version:** 3.2.1 → 3.2.2
**Author:** @supercollectible

### Checklist

- [x] `skillset.yaml` validated against schema
- [x] Version bumped from 3.2.1
- [x] `AUDIT_REPORT.md` generated and passing
- [x] `content/` directory updated

### Changes

_Describe what changed in this version._

---
Submitted via `npx skillsets submit`
