### PR TITLE
fix(valence): use URL object for .env path resolution on Windows

### DIFF
--- a/skillsets/@supercollectible/Valence/content/Valence_ext/external-agent.mjs
+++ b/skillsets/@supercollectible/Valence/content/Valence_ext/external-agent.mjs
@@ -9,9 +9,8 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { getProvider } from './providers/index.mjs';
 
 // Load .env from script directory (no dotenv dependency)
-const scriptDir = new URL('.', import.meta.url).pathname;
 try {
-  const envFile = await readFile(`${scriptDir}.env`, 'utf8');
+  const envFile = await readFile(new URL('.env', import.meta.url), 'utf8');
   for (const line of envFile.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;


### PR DESCRIPTION
## Problem

On Windows, `new URL('.', import.meta.url).pathname` returns a path like `/C:/path/Valence_ext/` — with a leading `/` prefix that makes it an invalid filesystem path for Node.js. The `catch {}` block silently swallowed the `readFile` error, so API keys (e.g. `KIMI_API_KEY`, `OPENROUTER_API_KEY`) were never loaded from `.env`, causing the agent to fail immediately with:

```
[agent] missing env var: KIMI_API_KEY
```

## Fix

Pass `new URL('.env', import.meta.url)` directly to `readFile`. Node.js natively accepts `URL` objects in filesystem APIs and resolves them correctly on all platforms (Linux, macOS, and Windows).

```diff
-const scriptDir = new URL('.', import.meta.url).pathname;
 try {
-  const envFile = await readFile(`${scriptDir}.env`, 'utf8');
+  const envFile = await readFile(new URL('.env', import.meta.url), 'utf8');
```

## Test

Verified locally on Windows 11 with Git Bash — external agents now load the `.env` file correctly and API key checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)